### PR TITLE
Release 1.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ Once `bblib.bash` is sourced in your script, you may refer to any of its supplie
   - Usage: `usage`
   - Notes: This is just an example. You should replace this with a similar function in your sourced conf file or in your main script.
 - `pprint`
-  - Description: Properly line-wraps text that is piped in to it
+  - Description: Properly line-wraps text that is piped in to it. It tries to auto-detect your terminal width, which can be set manually as the first argument, and has a hard fallback of 80.
   - Usage:
-    - `command | pprint`
-    - `pprint <<< "text"`
+    - `command | pprint [columns]`
+    - `pprint [columns] <<< "text"`
 - `inarray`
   - Description: Checks to see if a string is in an array and returns the index if true.
   - Usage: `inarray "${ARRAY[@]}" "SEARCHSTRING"`

--- a/README.md
+++ b/README.md
@@ -94,10 +94,9 @@ Once `bblib.bash` is sourced in your script, you may refer to any of its supplie
 - `prunner`
   - Description: Executes commands in parallel.
   - Usage:
-    - `prunner "command args" "command args"`
-    - `command_generator | prunner`
-    - `prunner -t 6 -c gzip FILE FILE FILE`
-    - `find . -type f | prunner -c "gzip -v" -t 8`
+    - `prunner "command arg" "command"`
+    - `prunner -t 6 -c gzip *.txt`
+    - `find . -name "*.txt" | prunner -c "gzip -v" -t 8`
   - Arguments:
     - `-c`: Command to prepend to each job line. If you do `-c gzip` and pipe in or suffix `prunner` with more lines, the resulting background command will be `gzip $JOBLINE`.
     - `-t`: Threads to use. Default is 8. You can alternately set the `THREADS` environment variable.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The _"Better BASH Library"_: A set of functions to assist with creating well-wri
 Add this to the top of your BASH script:
 
 ```bash
-source <(wget -qO- https://raw.githubusercontent.com/MrDrMcCoy/bblib/1.0.0/bblib.bash)
+source <(wget -qO- https://raw.githubusercontent.com/MrDrMcCoy/bblib/1.0.1/bblib.bash)
 ```
 
 Alternately, clone this repo locally and use `source` with the full path to `bblib.bash`.

--- a/bblib.bash
+++ b/bblib.bash
@@ -176,6 +176,7 @@ prunner () {
   set -x
   local CURRENT_FUNC="prunner"
   local PQUEUE=()
+  echo "args=$@"
   while getopts ":c:t:" OPT ; do
     case ${OPT} in
       c) local PCMD="${OPTARG}" ;;

--- a/bblib.bash
+++ b/bblib.bash
@@ -180,9 +180,9 @@ prunner () {
   #   prunner -t 6 -c gzip FILE FILE FILE
   #   find . -type f | prunner -c gzip -t 8
   local CURRENT_FUNC="prunner"
-  local PQUEUE=()
   echo "args=$@"
   # Process options
+  set -x
   while getopts ":c:t:" OPT ; do
     case ${OPT} in
       c) local PCMD="${OPTARG}" ; echo "-c was set" ;;
@@ -191,7 +191,9 @@ prunner () {
       *) quit "ERROR" "Option '-${OPTARG}' is not defined." ;;
     esac
   done
+  set +x
   echo "PCMD='$PCMD' THREADS='$THREADS'"
+  local PQUEUE=()
   # Add input lines to queue, split by newlines
   if [ ! -t 0 ] ; then
     while read -r LINE ; do

--- a/bblib.bash
+++ b/bblib.bash
@@ -173,53 +173,37 @@ argparser () {
 }
 
 prunner () {
-  # Executes jobs in parallel
-  # Usage:
-  #   prunner "command args" "command args"
-  #   command_generator | prunner
-  #   prunner -t 6 -c gzip FILE FILE FILE
-  #   find . -type f | prunner -c gzip -t 8
-  local CURRENT_FUNC="prunner"
-  echo "args=$@"
-  # Process options
-  set -x
+  local PQUEUE=()
   while getopts ":c:t:" OPT ; do
     case ${OPT} in
-      c) local PCMD="${OPTARG}" ; echo "-c was set" ;;
-      t) local THREADS="${OPTARG}" ; echo "-t was set" ;;
+      c) local PCMD="${OPTARG}" ;;
+      t) local THREADS="${OPTARG}" ;;
       :) quit "ERROR" "Option '-${OPTARG}' requires an argument." ;;
       *) quit "ERROR" "Option '-${OPTARG}' is not defined." ;;
     esac
   done
-  set +x
-  echo "PCMD='$PCMD' THREADS='$THREADS'"
-  local PQUEUE=()
-  # Add input lines to queue, split by newlines
+  shift $(($OPTIND-1))
+  for ARG in "$@" ; do
+    PQUEUE+=("$ARG")
+  done
   if [ ! -t 0 ] ; then
     while read -r LINE ; do
       PQUEUE+=("$LINE")
     done
   fi
-  # Add non-option arguments to queue
-  shift $(($OPTIND-1))
-  for ARG in "$@" ; do
-    PQUEUE+=("$ARG")
-  done
   local QCOUNT="${#PQUEUE[@]}"
   local INDEX=0
-  echo "PCMD='$PCMD' THREADS='$THREADS' QCOUNT='$QCOUNT'"
-  # Start running the commands in the queue
-  log "DEBUG" "Starting parallel execution of $QCOUNT jobs with ${THREADS:-8} threads using command prefix '$PCMD'."
+  echo "Starting parallel execution of $QCOUNT jobs with ${THREADS:-8} threads using command prefix '$PCMD'."
   until [ ${#PQUEUE[@]} == 0 ] ; do
     if [ "$(jobs -rp | wc -l)" -lt "${THREADS:-8}" ] ; then
-      log "DEBUG" "Starting command in parallel ($(($INDEX+1))/$QCOUNT): ${PCMD} ${PQUEUE[$INDEX]}"
-      eval "${PCMD} ${PQUEUE[$INDEX]}" |& log "DEBUG" || true &
+      echo "Starting command in parallel ($(($INDEX+1))/$QCOUNT): ${PCMD} ${PQUEUE[$INDEX]}"
+      eval "${PCMD} ${PQUEUE[$INDEX]}" || true &
       unset PQUEUE[$INDEX]
-      ((INDEX++)) || true # I have no idea why this needs '|| true', but it does and it works.
+      ((INDEX++)) || true
     fi
   done
   wait
-  log "DEBUG" "Parallel execution finished for $QCOUNT jobs."
+  echo "Parallel execution finished for $QCOUNT jobs."
 }
 
 # Trap for killing runaway processes and exiting

--- a/bblib.bash
+++ b/bblib.bash
@@ -181,15 +181,17 @@ prunner () {
   #   find . -type f | prunner -c gzip -t 8
   local CURRENT_FUNC="prunner"
   local PQUEUE=()
+  echo "args=$@"
   # Process options
   while getopts ":c:t:" OPT ; do
     case ${OPT} in
-      c) local PCMD="${OPTARG}" ;;
-      t) local THREADS="${OPTARG}" ;;
+      c) local PCMD="${OPTARG}" ; echo "-c was set" ;;
+      t) local THREADS="${OPTARG}" ; echo "-t was set" ;;
       :) quit "ERROR" "Option '-${OPTARG}' requires an argument." ;;
       *) quit "ERROR" "Option '-${OPTARG}' is not defined." ;;
     esac
   done
+  echo "PCMD='$PCMD' THREADS='$THREADS'"
   # Add input lines to queue, split by newlines
   if [ ! -t 0 ] ; then
     while read -r LINE ; do
@@ -203,6 +205,7 @@ prunner () {
   done
   local QCOUNT="${#PQUEUE[@]}"
   local INDEX=0
+  echo "PCMD='$PCMD' THREADS='$THREADS' QCOUNT='$QCOUNT'"
   # Start running the commands in the queue
   log "DEBUG" "Starting parallel execution of $QCOUNT jobs with ${THREADS:-8} threads using command prefix '$PCMD'."
   until [ ${#PQUEUE[@]} == 0 ] ; do

--- a/bblib.bash
+++ b/bblib.bash
@@ -190,7 +190,7 @@ prunner () {
       :) quit "ERROR" "Option '-${OPTARG}' requires an argument." ;;
       *) quit "ERROR" "Option '-${OPTARG}' is not defined." ;;
     esac
-  done
+  done <<< "$@"
   # Add input lines to queue, split by newlines
   if [ ! -t 0 ] ; then
     while read -r LINE ; do

--- a/bblib.bash
+++ b/bblib.bash
@@ -173,6 +173,14 @@ argparser () {
 }
 
 prunner () {
+  # Run commands in parallel
+  # Options:
+  #   -t [threads]
+  #   -c [command to pass arguments to]
+  # Usage:
+  #   prunner "command arg" "command"
+  #   prunner -c gzip *.txt
+  #   find . | prunner -c 'echo found file:' -t 6
   local CURRENT_FUNC="prunner"
   local PQUEUE=()
   while getopts ":c:t:" OPT ; do

--- a/bblib.bash
+++ b/bblib.bash
@@ -182,12 +182,6 @@ prunner () {
   local CURRENT_FUNC="prunner"
   local JOB_QUEUE=()
   local COMMAND=""
-  # Add input lines to queue, split by newlines
-  if [ ! -t 0 ] ; then
-    while read -r LINE ; do
-      JOB_QUEUE+=("$LINE")
-    done
-  fi
   # Process options
   while getopts ":c:t:" OPT ; do
     case ${OPT} in
@@ -197,6 +191,12 @@ prunner () {
       *) quit "ERROR" "Option '-${OPTARG}' is not defined." ;;
     esac
   done
+  # Add input lines to queue, split by newlines
+  if [ ! -t 0 ] ; then
+    while read -r LINE ; do
+      JOB_QUEUE+=("$LINE")
+    done
+  fi
   # Add non-option arguments to queue
   shift $(($OPTIND-1))
   for ARG in "$@" ; do

--- a/bblib.bash
+++ b/bblib.bash
@@ -145,6 +145,7 @@ checkpid () {
 requireuser () {
   # Checks to see if current user matches $REQUIREUSER and exits if not.
   # REQUIREUSER can be set as a variable or passed in as an argument.
+  # Usage: requireuser [user]
   local CURRENT_FUNC="requireuser"
   local REQUIREUSER="${1:-$REQUIREUSER}"
   if [ -z $REQUIREUSER ] ; then
@@ -157,6 +158,7 @@ requireuser () {
 }
 
 usage () {
+  # Print usage information
 pprint << HERE
 $0: An example script
 
@@ -182,7 +184,7 @@ argparser () {
       s) source "${OPTARG}" ;;
       v) set -x ; export LOGLEVEL=DEBUG ;;
       :) quit "ERROR" "Option '-${OPTARG}' requires an argument. For usage, try '${0} -h'." ;;
-      *) quit "ERROR" "Invalid option: '-${OPTARG}'. For usage, try '${0} -h'." ;;
+      *) quit "ERROR" "Option '-${OPTARG}' is not defined. For usage, try '${0} -h'." ;;
     esac
   done
 }

--- a/bblib.bash
+++ b/bblib.bash
@@ -183,8 +183,8 @@ prunner () {
   local JOB_QUEUE=()
   local COMMAND=""
   # Process options
-  set -x
   log "DEBUG" "ARGS='$@'"
+  set -x
   while getopts "c:t:" OPT ; do
     case ${OPT} in
       c) local COMMAND="${OPTARG}" ; echo "COMMAND=$COMMAND" ;;
@@ -192,7 +192,7 @@ prunner () {
       :) quit "ERROR" "Option '-${OPTARG}' requires an argument." ;;
       *) quit "ERROR" "Option '-${OPTARG}' is not defined." ;;
     esac
-  done |& log "DEBUG"
+  done
   set +x
   # Add input lines to queue, split by newlines
   if [ ! -t 0 ] ; then

--- a/bblib.bash
+++ b/bblib.bash
@@ -184,16 +184,14 @@ prunner () {
   local COMMAND=""
   # Process options
   echo "ARGS='$@'"
-  set -x
-  while getopts "c:t:" OPT ; do
+  while getopts ":c:t:" OPT ; do
     case ${OPT} in
-      c) local COMMAND="${OPTARG}" ; echo "COMMAND=$COMMAND" ;;
-      t) local THREADS="${OPTARG}" ; echo "THREADS=$THREADS" ;;
+      c) COMMAND="${OPTARG}" ;;
+      t) THREADS="${OPTARG}" ;;
       :) quit "ERROR" "Option '-${OPTARG}' requires an argument." ;;
       *) quit "ERROR" "Option '-${OPTARG}' is not defined." ;;
     esac
   done
-  set +x
   # Add input lines to queue, split by newlines
   if [ ! -t 0 ] ; then
     while read -r LINE ; do

--- a/bblib.bash
+++ b/bblib.bash
@@ -185,8 +185,8 @@ prunner () {
   # Process options
   while getopts ":c:t:" OPT ; do
     case ${OPT} in
-      c) local COMMAND="${OPTARG}" ;;
-      t) local THREADS="${OPTARG}" ;;
+      c) local COMMAND="${OPTARG}" ; log "DEBUG" "COMMAND=$COMMAND" ;;
+      t) local THREADS="${OPTARG}" ; log "DEBUG" "THREADS=$THREADS" ;;
       :) quit "ERROR" "Option '-${OPTARG}' requires an argument." ;;
       *) quit "ERROR" "Option '-${OPTARG}' is not defined." ;;
     esac
@@ -206,8 +206,8 @@ prunner () {
   local JOB_INDEX=0
   local THREADS=${THREADS:-8}
   # Start running the commands in the queue
-  log "DEBUG" "Starting parallel execution of $JOB_MAX jobs with $THREADS threads."
-  until [ ${#JOB_QUEUE[@]} = 0 ] ; do
+  log "DEBUG" "Starting parallel execution of $JOB_MAX jobs with $THREADS threads using command prefix '$COMMAND'."
+  until [ ${#JOB_QUEUE[@]} == 0 ] ; do
     if [ "$(jobs -rp | wc -l)" -lt "${THREADS}" ] ; then
       log "DEBUG" "Starting command in parallel ($(($JOB_INDEX+1))/$JOB_MAX): ${COMMAND} ${JOB_QUEUE[$JOB_INDEX]}"
       eval "${COMMAND} ${JOB_QUEUE[$JOB_INDEX]}" |& log "DEBUG" || true &

--- a/bblib.bash
+++ b/bblib.bash
@@ -122,7 +122,7 @@ checkpid () {
     quit "WARN" "This script is already running with PID $(cat "${PIDFILE}" 2> /dev/null), exiting"
   else
     echo -n "$$" > "${PIDFILE}"
-    FINALCMDS+=("rm -v '${PIDFILE}'")
+    FINALCMDS+=("rm '${PIDFILE}'")
     log "DEBUG" "PID $$ has no conflicts and has been written to ${PIDFILE}"
   fi
 }

--- a/bblib.bash
+++ b/bblib.bash
@@ -183,7 +183,7 @@ prunner () {
   local JOB_QUEUE=()
   local COMMAND=""
   # Process options
-  log "DEBUG" "ARGS='$@'"
+  echo "ARGS='$@'"
   set -x
   while getopts "c:t:" OPT ; do
     case ${OPT} in

--- a/bblib.bash
+++ b/bblib.bash
@@ -173,6 +173,8 @@ argparser () {
 }
 
 prunner () {
+  set -x
+  local CURRENT_FUNC="prunner"
   local PQUEUE=()
   while getopts ":c:t:" OPT ; do
     case ${OPT} in
@@ -204,6 +206,7 @@ prunner () {
   done
   wait
   echo "Parallel execution finished for $QCOUNT jobs."
+  set +x
 }
 
 # Trap for killing runaway processes and exiting

--- a/bblib.bash
+++ b/bblib.bash
@@ -173,7 +173,7 @@ argparser () {
 }
 
 prunner () {
-  #set -x
+  set -x
   local CURRENT_FUNC="prunner"
   local PQUEUE=()
   while getopts ":c:t:" OPT ; do
@@ -206,7 +206,7 @@ prunner () {
   done
   wait
   echo "Parallel execution finished for $QCOUNT jobs."
-  #set +x
+  set +x
 }
 
 # Trap for killing runaway processes and exiting

--- a/bblib.bash
+++ b/bblib.bash
@@ -183,6 +183,7 @@ prunner () {
   local JOB_QUEUE=()
   local COMMAND=""
   # Process options
+  set -x
   while getopts ":c:t:" OPT ; do
     case ${OPT} in
       c) local COMMAND="${OPTARG}" ; log "DEBUG" "COMMAND=$COMMAND" ;;
@@ -190,7 +191,8 @@ prunner () {
       :) quit "ERROR" "Option '-${OPTARG}' requires an argument." ;;
       *) quit "ERROR" "Option '-${OPTARG}' is not defined." ;;
     esac
-  done <<< "$@"
+  done
+  set +x
   # Add input lines to queue, split by newlines
   if [ ! -t 0 ] ; then
     while read -r LINE ; do

--- a/bblib.bash
+++ b/bblib.bash
@@ -10,9 +10,9 @@ FINALCMDS=()
 pprint () {
   # Function to properly wrap and print text
   # Usage:
-  #   command | pprint
+  #   command | pprint [columns]
   #   pprint <<< "text"
-  local COLUMNS="${COLUMNS:-$(tput cols)}"
+  local COLUMNS="${1:-${COLUMNS:-$(tput cols)}}"
   fold -sw "${COLUMNS:-80}"
 }
 
@@ -35,12 +35,26 @@ inarray () {
   return 1
 }
 
-# Convert to uppercase
-uc () { tr "[:lower:]" "[:upper:]" <<< "${@:-$(cat /dev/stdin)}" ; }
-# Convert to lowercase
-lc () { tr "[:upper:]" "[:lower:]" <<< "${@:-$(cat /dev/stdin)}" ; }
-# Print horizontal rule
+lc () {
+  # Convert stdin/arguments to lowercase
+  # Usage:
+  #   lc [string]
+  #   command | lc
+  tr "[:upper:]" "[:lower:]" <<< "${@:-$(cat /dev/stdin)}"
+}
+
+uc () {
+  # Convert stdin/arguments to uppercase
+  # Usage:
+  #   uc [string]
+  #   command | uc
+  tr "[:lower:]" "[:upper:]" <<< "${@:-$(cat /dev/stdin)}"
+}
+
 hr () {
+  # Print horizontal rule
+  # Usage:
+  #   hr [character]
   local CHARACTER="${1:0:1}"
   local COLUMNS=${COLUMNS:-$(tput cols)}
   printf '%*s\n' "${COLUMNS:-80}" '' | tr ' ' "${CHARACTER:--}"
@@ -53,7 +67,6 @@ log () {
   #     log $SEVERITY $MESSAGE
   # Variables:
   #     LOGLEVEL: The cutoff for message severity to log (Default is INFO).
-  #####
   local SEVERITY="$(uc "${1:-NOTICE}")"
   local LOGMSG="${2:-$(cat /dev/stdin)}"
   local LOGLEVELS=(EMERGENCY ALERT CRITICAL ERROR WARN NOTICE INFO DEBUG)
@@ -61,7 +74,7 @@ log () {
   local LOGTAG="[${SCRIPT_NAME:-$0}] [${CURRENT_FUNC:-SCRIPT_ROOT}] [${SEVERITY}]"
   local NUMERIC_LOGLEVEL="$(inarray "${LOGLEVELS[@]}" "${LOGLEVEL}")"
   local NUMERIC_SEVERITY="$(inarray "${LOGLEVELS[@]}" "${SEVERITY}")"
-  #####
+
   if [ ${NUMERIC_SEVERITY:-5} -le ${NUMERIC_LOGLEVEL:-6} ] ; then
     while read -r LINE ; do
       logger -is -p user.${NUMERIC_SEVERITY:-5} -t "${LOGTAG} " -- "${LINE}"
@@ -94,6 +107,7 @@ quit () {
 
 bash4check () {
   # Call this function to enable features that depend on bash 4.0+.
+  # Usage: bash4check
   if [ ${BASH_VERSINFO[0]} -lt 4 ] ; then
     log "ERROR" "Sorry, you need at least bash version 4 to run this function: $CURRENT_FUNC"
     return 1
@@ -106,14 +120,15 @@ finally () {
   # Function to perform final tasks before exit
   local CURRENT_FUNC="finally"
   until [ "${#FINALCMDS[@]}" == 0 ] ; do
-      log "DEBUG" "Executing pre-exit command: ${FINALCMDS[-1]}"
-      eval "${FINALCMDS[-1]}"
-      unset FINALCMDS[-1]
+    log "DEBUG" "Executing pre-exit command: ${FINALCMDS[-1]}"
+    eval "${FINALCMDS[-1]}"
+    unset FINALCMDS[-1]
   done
 }
 
 checkpid () {
   # Check for and maintain pidfile
+  # Usage: checkpid
   local CURRENT_FUNC="checkpid"
   local PIDFILE="${PIDFILE:-${0}.pid}"
   if [ ! -d "/proc/$$" ]; then
@@ -165,7 +180,7 @@ argparser () {
     case ${OPT} in
       h) usage ;;
       s) source "${OPTARG}" ;;
-      v) set -x ; LOGLEVEL=DEBUG ;;
+      v) set -x ; export LOGLEVEL=DEBUG ;;
       :) quit "ERROR" "Option '-${OPTARG}' requires an argument. For usage, try '${0} -h'." ;;
       *) quit "ERROR" "Invalid option: '-${OPTARG}'. For usage, try '${0} -h'." ;;
     esac
@@ -183,6 +198,7 @@ prunner () {
   #   find . | prunner -c 'echo found file:' -t 6
   local CURRENT_FUNC="prunner"
   local PQUEUE=()
+  # Process option arguments
   while getopts ":c:t:" OPT ; do
     case ${OPT} in
       c) local PCMD="${OPTARG}" ;;
@@ -191,10 +207,13 @@ prunner () {
       *) quit "ERROR" "Option '-${OPTARG}' is not defined." ;;
     esac
   done
+  # Throw away option arguments so that non-option arguments can be queued
   shift $(($OPTIND-1))
+  # Add non-option arguments to queue
   for ARG in "$@" ; do
     PQUEUE+=("$ARG")
   done
+  # Add lines from stdin to queue
   if [ ! -t 0 ] ; then
     while read -r LINE ; do
       PQUEUE+=("$LINE")

--- a/bblib.bash
+++ b/bblib.bash
@@ -173,7 +173,7 @@ argparser () {
 }
 
 prunner () {
-  set -x
+  #set -x
   local CURRENT_FUNC="prunner"
   local PQUEUE=()
   while getopts ":c:t:" OPT ; do
@@ -206,7 +206,7 @@ prunner () {
   done
   wait
   echo "Parallel execution finished for $QCOUNT jobs."
-  set +x
+  #set +x
 }
 
 # Trap for killing runaway processes and exiting

--- a/bblib.bash
+++ b/bblib.bash
@@ -182,6 +182,12 @@ prunner () {
   local CURRENT_FUNC="prunner"
   local JOB_QUEUE=()
   local COMMAND=""
+  # Add input lines to queue, split by newlines
+  if [ ! -t 0 ] ; then
+    while read -r LINE ; do
+      JOB_QUEUE+=("$LINE")
+    done
+  fi
   # Process options
   while getopts ":c:t:" OPT ; do
     case ${OPT} in
@@ -191,12 +197,6 @@ prunner () {
       *) quit "ERROR" "Option '-${OPTARG}' is not defined." ;;
     esac
   done
-  # Add input lines to queue, split by newlines
-  if [ ! -t 0 ] ; then
-    while read -r LINE ; do
-      JOB_QUEUE+=("$LINE")
-    done
-  fi
   # Add non-option arguments to queue
   shift $(($OPTIND-1))
   for ARG in "$@" ; do

--- a/bblib.bash
+++ b/bblib.bash
@@ -173,10 +173,8 @@ argparser () {
 }
 
 prunner () {
-  set -x
   local CURRENT_FUNC="prunner"
   local PQUEUE=()
-  echo "args=$@"
   while getopts ":c:t:" OPT ; do
     case ${OPT} in
       c) local PCMD="${OPTARG}" ;;
@@ -196,18 +194,17 @@ prunner () {
   fi
   local QCOUNT="${#PQUEUE[@]}"
   local INDEX=0
-  echo "Starting parallel execution of $QCOUNT jobs with ${THREADS:-8} threads using command prefix '$PCMD'."
+  log "INFO" "Starting parallel execution of $QCOUNT jobs with ${THREADS:-8} threads using command prefix '$PCMD'."
   until [ ${#PQUEUE[@]} == 0 ] ; do
     if [ "$(jobs -rp | wc -l)" -lt "${THREADS:-8}" ] ; then
-      echo "Starting command in parallel ($(($INDEX+1))/$QCOUNT): ${PCMD} ${PQUEUE[$INDEX]}"
-      eval "${PCMD} ${PQUEUE[$INDEX]}" || true &
+      log "DEBUG" "Starting command in parallel ($(($INDEX+1))/$QCOUNT): ${PCMD} ${PQUEUE[$INDEX]}"
+      eval "${PCMD} ${PQUEUE[$INDEX]}" |& log "DEBUG" || true &
       unset PQUEUE[$INDEX]
       ((INDEX++)) || true
     fi
   done
   wait
-  echo "Parallel execution finished for $QCOUNT jobs."
-  set +x
+  log "INFO" "Parallel execution finished for $QCOUNT jobs."
 }
 
 # Trap for killing runaway processes and exiting

--- a/bblib.bash
+++ b/bblib.bash
@@ -184,14 +184,15 @@ prunner () {
   local COMMAND=""
   # Process options
   set -x
-  while getopts ":c:t:" OPT ; do
+  log "DEBUG" "ARGS='$@'"
+  while getopts "c:t:" OPT ; do
     case ${OPT} in
-      c) local COMMAND="${OPTARG}" ; log "DEBUG" "COMMAND=$COMMAND" ;;
-      t) local THREADS="${OPTARG}" ; log "DEBUG" "THREADS=$THREADS" ;;
+      c) local COMMAND="${OPTARG}" ; echo "COMMAND=$COMMAND" ;;
+      t) local THREADS="${OPTARG}" ; echo "THREADS=$THREADS" ;;
       :) quit "ERROR" "Option '-${OPTARG}' requires an argument." ;;
       *) quit "ERROR" "Option '-${OPTARG}' is not defined." ;;
     esac
-  done
+  done |& log "DEBUG"
   set +x
   # Add input lines to queue, split by newlines
   if [ ! -t 0 ] ; then

--- a/tests/test.bash
+++ b/tests/test.bash
@@ -69,9 +69,8 @@ main () {
   # Parallel test
   log "DEBUG" "Test prunner gzipping the .out files with arguments for the jobs"
   prunner -c "gzip -fk" *.out
-  log "DEBUG" "Test prunner gzipping the .out files with stdin for the jobs"
-  find . -maxdepth 1 -type f | prunner -c "echo found file:" -t 18
-  #find . -maxdepth 1 -name "*.out" | prunner -c "gzip -fk"
+  log "DEBUG" "Test prunner echoing the .out files with stdin for the jobs"
+  find . -maxdepth 1 -type f -name "*.out" | prunner -c "echo found file:" -t 18
 
   # Add cleanup tasks
   FINALCMDS+=('rm *.out')

--- a/tests/test.bash
+++ b/tests/test.bash
@@ -69,9 +69,8 @@ main () {
   # Parallel test
   log "DEBUG" "Test prunner gzipping the .out files with arguments for the jobs"
   prunner -c "gzip -fk" *.out
-  log "DEBUG" "Test prunner gzipping the .out files with stdin for the jobs"
-  #find . -maxdepth 1 -type f | prunner -c "echo found file:" -t 18
-  find . -maxdepth 1 -name "*.out" | prunner -c "gzip -fk" -t 18
+  log "DEBUG" "Test prunner echoing the .out files with stdin for the jobs"
+  find . -maxdepth 1 -name "*.out" | prunner -c "echo found file:" -t 18
 
   # Add cleanup tasks
   FINALCMDS+=('rm *.out')

--- a/tests/test.bash
+++ b/tests/test.bash
@@ -70,7 +70,7 @@ main () {
   log "DEBUG" "Test prunner gzipping the .out files with arguments for the jobs"
   prunner -c "gzip -fk" *.out
   log "DEBUG" "Test prunner gzipping the .out files with stdin for the jobs"
-  find . -mindepth 1 -maxdepth 1 -name "*.out" | prunner -c "gzip -fk"
+  find . -maxdepth 1 -name "*.out" | prunner -c "gzip -fk"
 
   # Add cleanup tasks
   FINALCMDS+=('rm *.out')

--- a/tests/test.bash
+++ b/tests/test.bash
@@ -70,7 +70,7 @@ main () {
   log "DEBUG" "Test prunner gzipping the .out files with arguments for the jobs"
   prunner -c "gzip -fk" *.out
   log "DEBUG" "Test prunner echoing the .out files with stdin for the jobs"
-  find . -maxdepth 1 -type f -name "*.out" | prunner -c "echo found file" -t 18
+  find . -maxdepth 1 -type f -name "*.out" | prunner -c echo -t 18
 
   # Add cleanup tasks
   FINALCMDS+=('rm *.out')

--- a/tests/test.bash
+++ b/tests/test.bash
@@ -70,7 +70,7 @@ main () {
   log "DEBUG" "Test prunner gzipping the .out files with arguments for the jobs"
   prunner -c "gzip -fk" *.out
   log "DEBUG" "Test prunner echoing the .out files with stdin for the jobs"
-  find . -maxdepth 1 -type f -name "*.out" | prunner -c "echo found file:" -t 18
+  find . -maxdepth 1 -type f -name "*.out" | prunner -c "echo found file" -t 18
 
   # Add cleanup tasks
   FINALCMDS+=('rm *.out')

--- a/tests/test.bash
+++ b/tests/test.bash
@@ -70,8 +70,8 @@ main () {
   log "DEBUG" "Test prunner gzipping the .out files with arguments for the jobs"
   prunner -c "gzip -fk" *.out
   log "DEBUG" "Test prunner gzipping the .out files with stdin for the jobs"
-  find . -maxdepth 1 -type f | prunner -c "echo found file:" -t 18
-  #find . -maxdepth 1 -name "*.out" | prunner -c "gzip -fk"
+  #find . -maxdepth 1 -type f | prunner -c "echo found file:" -t 18
+  find . -maxdepth 1 -name "*.out" | prunner -c "gzip -fk"
 
   # Add cleanup tasks
   FINALCMDS+=('rm *.out')

--- a/tests/test.bash
+++ b/tests/test.bash
@@ -71,7 +71,7 @@ main () {
   prunner -c "gzip -fk" *.out
   log "DEBUG" "Test prunner gzipping the .out files with stdin for the jobs"
   #find . -maxdepth 1 -type f | prunner -c "echo found file:" -t 18
-  find . -maxdepth 1 -name "*.out" | prunner -c "gzip -fk"
+  find . -maxdepth 1 -name "*.out" | prunner -c "gzip -fk" -t 18
 
   # Add cleanup tasks
   FINALCMDS+=('rm *.out')

--- a/tests/test.bash
+++ b/tests/test.bash
@@ -69,8 +69,9 @@ main () {
   # Parallel test
   log "DEBUG" "Test prunner gzipping the .out files with arguments for the jobs"
   prunner -c "gzip -fk" *.out
-  log "DEBUG" "Test prunner echoing the .out files with stdin for the jobs"
-  find . -maxdepth 1 -name "*.out" | prunner -c "echo found file:" -t 18
+  log "DEBUG" "Test prunner gzipping the .out files with stdin for the jobs"
+  find . -maxdepth 1 -type f | prunner -c "echo found file:" -t 18
+  #find . -maxdepth 1 -name "*.out" | prunner -c "gzip -fk"
 
   # Add cleanup tasks
   FINALCMDS+=('rm *.out')

--- a/tests/test.bash
+++ b/tests/test.bash
@@ -70,7 +70,8 @@ main () {
   log "DEBUG" "Test prunner gzipping the .out files with arguments for the jobs"
   prunner -c "gzip -fk" *.out
   log "DEBUG" "Test prunner gzipping the .out files with stdin for the jobs"
-  find . -maxdepth 1 -name "*.out" | prunner -c "gzip -fk"
+  find . -maxdepth 1 -type f | prunner -c "echo found file:" -t 18
+  #find . -maxdepth 1 -name "*.out" | prunner -c "gzip -fk"
 
   # Add cleanup tasks
   FINALCMDS+=('rm *.out')

--- a/tests/test.bash
+++ b/tests/test.bash
@@ -70,7 +70,7 @@ main () {
   log "DEBUG" "Test prunner gzipping the .out files with arguments for the jobs"
   prunner -c "gzip -fk" *.out
   log "DEBUG" "Test prunner gzipping the .out files with stdin for the jobs"
-  prunner -c "gzip -fk" <<< *.out
+  find . -mindepth 1 -maxdepth 1 -name "*.out" | prunner -c "gzip -fk"
 
   # Add cleanup tasks
   FINALCMDS+=('rm *.out')

--- a/tests/test.bash
+++ b/tests/test.bash
@@ -67,8 +67,10 @@ main () {
   done
 
   # Parallel test
-  log "DEBUG" "Test prunner gzipping the .out files"
-  prunner -c "gzip -k" *.out
+  log "DEBUG" "Test prunner gzipping the .out files with arguments for the jobs"
+  prunner -c "gzip -fk" *.out
+  log "DEBUG" "Test prunner gzipping the .out files with stdin for the jobs"
+  prunner -c "gzip -fk" <<< *.out
 
   # Add cleanup tasks
   FINALCMDS+=('rm *.out')

--- a/tests/test.bash.conf
+++ b/tests/test.bash.conf
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 # Set test variables:
-export SCRIPT_NAME="bblib_test"
-export LOGLEVEL="DEBUG"
-export LOGFILE="bblib_test.log"
-export PIDFILE="bblib_test.pid"
-export REQUIREUSER="whoever"
-export THREADS=16
+SCRIPT_NAME="bblib_test"
+LOGLEVEL="DEBUG"
+LOGFILE="bblib_test.log"
+PIDFILE="bblib_test.pid"
+REQUIREUSER="whoever"
+THREADS=16


### PR DESCRIPTION
- Re-worked `prunner` to better support actions from stdin. It passes tests interactively, but the same commands from within the test script refuse to set the command with `-c`. 
- `pprint` now allows you to manually set columns.
- Added better in-line documentation
- Updated README.md